### PR TITLE
set up aac link redirect

### DIFF
--- a/src/app/link/[slug]/page.tsx
+++ b/src/app/link/[slug]/page.tsx
@@ -1,0 +1,21 @@
+import { redirect, notFound } from 'next/navigation';
+
+const redirects: Record<string, string> = {
+  'retreat-signup-form': 'https://forms.gle/Km3ZYZbnctYR1oDs6',
+  'membership-form': 'https://forms.gle/scCH6xnyZphLSBCPA',
+  // more events (e.g. weekend event, gen meeting sign in form, etc.)
+};
+
+export default function RedirectPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const destination = redirects[params.slug];
+
+  if (!destination) {
+    notFound();
+  }
+
+  redirect(destination);
+}


### PR DESCRIPTION
Created a system where, when a user goes to `/link/[slug]`, if `slug` matches something in the `redirects` object in `@/app/link/[slug]/page.tsx`, the link will redirect to the corresponding value. For example, `/link/retreat-signup-form` redirects to the retreat sign up google form.

For now, adding/updating links requires hard-coding the values into the object, but in the future, we can configure more advanced methods of updating links, e.g. including a database/dashboard/discord command.

Solves #21 